### PR TITLE
test: ensure coordinates round to six decimals

### DIFF
--- a/src/domain/value-object/coordinates.value-object.spec.ts
+++ b/src/domain/value-object/coordinates.value-object.spec.ts
@@ -27,6 +27,19 @@ describe('Coordinates', () => {
     expect(coords.value.longitude).toBe(90);
   });
 
+  it('should round coordinates to six decimal places', () => {
+    // Arrange
+    const latitude = 1.23456789;
+    const longitude = 9.87654321;
+
+    // Act
+    const coords = new Coordinates({ latitude, longitude });
+
+    // Assert
+    expect(coords.value.latitude).toBe(1.234568);
+    expect(coords.value.longitude).toBe(9.876543);
+  });
+
   it('should throw for invalid latitude', () => {
     // Arrange
     const invalidLatitude = 100;


### PR DESCRIPTION
## Summary
- add unit test ensuring Coordinates rounds latitude and longitude to six decimal places

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba3df0ae88328bce2eef230b20e4d